### PR TITLE
add and rename some functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ g++ main.cpp -o sparserref -O3 -std=c++20 -I$INCULDE -L$LIB -lflint -lgmp
 
 Shared library for [Wolfram LibraryLink](https://reference.wolfram.com/language/guide/LibraryLink.html) API (used by Mathematica package [SparseRREF.wl](SparseRREF.wl), see below):
 ```bash
-g++ mma_link.cpp -fPIC -shared -O3 -std=c++20 -o mathlink.dll -I$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C -I$INCLUDE -L$LIB -lflint -lgmp
+g++ sprreflink.cpp -fPIC -shared -O3 -std=c++20 -o sprreflink.dll -I$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C -I$INCLUDE -L$LIB -lflint -lgmp
 ```
 where we assume that the FLINT library and GMP library are installed in `$LIB`, the header files are in `$INCLUDE`,
 and `$MATHEMATICA_HOME/SystemFiles/IncludeFiles/C` is the path of Mathematica C header files.
@@ -107,7 +107,7 @@ The main function is `sparse_mat_rref`, its output is its pivots, and it modifie
 
 #### Mathematica API
 
-The Mathematica package [SparseRREF.wl](SparseRREF.wl) allows to call functions exported in [mma_link.cpp](mma_link.cpp):
+The Mathematica package [SparseRREF.wl](SparseRREF.wl) allows to call functions exported in [sprreflink.cpp](sprreflink.cpp):
 
 Example usage:
 ```mathematica
@@ -125,7 +125,7 @@ p = 7;
 {rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
 ```
 
-To use this package, you have to compile [mma_link.cpp](mma_link.cpp) to a shared library (`mathlink.dll` on Windows, `mathlink.so` on Linux, `mathlink.dylib` on macOS) in the same directory with [SparseRREF.wl](SparseRREF.wl).
+To use this package, you have to compile [sprreflink.cpp](sprreflink.cpp) to a shared library (`sprreflink.dll` on Windows, `sprreflink.so` on Linux, `sprreflink.dylib` on macOS) in the same directory with [SparseRREF.wl](SparseRREF.wl).
 
 See comments in [SparseRREF.wl](SparseRREF.wl) for more details.
 

--- a/SparseRREF.wl
+++ b/SparseRREF.wl
@@ -6,7 +6,7 @@
   See details at https://github.com/munuxi/SparseRREF
   
   Prerequisites:
-  - Compile mma_link.cpp to shared library mathlink.$EXT ($EXT = "dll" on Windows, "so" on Linux, "dylib" on macOS)
+  - Compile sprreflink.cpp to shared library sprreflink.$EXT ($EXT = "dll" on Windows, "so" on Linux, "dylib" on macOS)
   - Store SparseRREF.wl in the same directory.
 
   Available functions:
@@ -78,7 +78,7 @@ Begin["`Private`"];
 
 $sparseRREFDirectory = DirectoryName[$InputFileName];
 (* TODO rename e.g. to SparseRREF_MMA or SparseRREF_LibraryLink *)
-$sparseRREFLibName = "mathlink";
+$sparseRREFLibName = "sprreflink";
 
 (* TODO: shall we search in all directories from $LibraryPath? *)
 $sparseRREFLib = FindLibrary @ FileNameJoin @ {$sparseRREFDirectory, $sparseRREFLibName};
@@ -89,10 +89,10 @@ If[FailureQ[$sparseRREFLib],
 
 (* TODO: provide API for other exported functions: modpmatmul, ratmat_inv *)
 
-rationalRREFLibFunction =
+ratRREFLibFunction =
   LibraryFunctionLoad[
     $sparseRREFLib,
-    "rational_rref",
+    "sprref_rat_rref",
     {
       {LibraryDataType[ByteArray], "Constant"},
       Integer,
@@ -108,7 +108,7 @@ rationalRREFLibFunction =
 modRREFLibFunction =
   LibraryFunctionLoad[
     $sparseRREFLib,
-    "modrref",
+    "sprref_mod_rref",
     {
       {LibraryDataType[SparseArray], "Constant"},
       Integer,
@@ -225,7 +225,7 @@ rationalRREF[
     verbose_?BooleanQ,
     printStep_?IntegerQ
   ] :=
-  BinaryDeserialize @ rationalRREFLibFunction[
+  BinaryDeserialize @ ratRREFLibFunction[
     BinarySerialize[mat],
     outputMode,
     method,

--- a/SparseRREF.wl
+++ b/SparseRREF.wl
@@ -8,48 +8,75 @@
   Prerequisites:
   - Compile sprreflink.cpp to shared library sprreflink.$EXT ($EXT = "dll" on Windows, "so" on Linux, "dylib" on macOS)
   - Store SparseRREF.wl in the same directory.
-
+  
   Available functions:
-  - SparseRREF
-
-  Options:
-  - "Modulus":
-    0: compute RREF over rational field.
-    prime number p: compute RREF over finite field Z/p (integers modulo p).
-  - "OutputMode" - return value of a function:
-    0, "RREF": rref
-    1, "RREF,Kernel": {rref, kernel}
-    2, "RREF,Pivots": {rref, pivots}
-    3, "RREF,Kernel,Pivots": {rref, kernel, pivots}
-  - "Method":
-    0, "RightAndLeft": right and left search
-    1, "Right": only right search (chooses the leftmost independent columns as pivots)
-    2, "Hybrid": hybrid
-  - "BackwardSubstitution":
-    True (default): submatrix rref[[ pivots[[All,1]], pivots[[All,2]] ]]$ is an identity matrix.
-    False: submatrix is upper triangular.
-  - "Threads": number of threads (nonnegative integer).
-  - "Verbose" (True | False): print steps.
-  - "PrintStep" (Integer): print each i-th step.
-
+  --------------------
+  SparseRREF[mat, opts]
+    Computes Row Reduced Echelon Form (and optionally kernel/pivots).
+    
+    Options:
+    - "Modulus":
+      0: compute over rational field (default).
+      prime p: compute over finite field Z/p.
+    - "OutputMode":
+      0, "RREF": returns rref (default).
+      1, "RREF,Kernel": returns {rref, kernel}.
+      2, "RREF,Pivots": returns {rref, pivots}.
+      3, "RREF,Kernel,Pivots": returns {rref, kernel, pivots}.
+    - "Method":
+      0, "RightAndLeft": right and left search (default).
+      1, "Right": only right search (chooses the leftmost independent columns as pivots).
+      2, "Hybrid": hybrid.
+    - "BackwardSubstitution":
+      True: submatrix rref[[ pivots[[All,1]], pivots[[All,2]] ]] is an identity matrix (default).
+      False: submatrix is upper triangular.
+    - "Threads": number of threads (Integer >= 0, with 0 meaning automatic).
+    - "Verbose": True | False.
+    - "PrintStep": Integer (print progress every n steps).
+    
+  SparseMatMul[matA, matB, opts]
+    Computes the exact matrix product of two sparse matrices.
+    
+    Options:
+    - "Modulus":
+      0: compute over rational field (default).
+      prime p: compute over finite field Z/p.
+    - "Threads": number of threads (Integer >= 0, with 0 meaning automatic).
+    
   Example usage:
+  --------------
     Needs["SparseRREF`"];
     (* or: Needs["SparseRREF`", "/path/to/SparseRREF.wl"]; *)
-
-    (* rationals *)
+    
+    (* --- RREF Example --- *)    
+    (* Rationals *)
     mat = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
     rref = SparseRREF[mat];
     {rref, kernel, pivots} = SparseRREF[mat, "OutputMode" -> "RREF,Kernel,Pivots", "Method" -> "Right", "BackwardSubstitution" -> True, "Threads" -> $ProcessorCount, "Verbose" -> True, "PrintStep" -> 10];
-
-    (* integers mod p *)
+    
+    (* Finite Field *)
     mat = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
     p = 7;
-    {rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 0];
+    {rref, kernel} = SparseRREF[mat, Modulus -> p, "OutputMode" -> "RREF,Kernel", "Method" -> "Hybrid", "Threads" -> 1];
+    
+    (* --- MatMul Example --- *)
+    (* Rationals *)
+    matA = SparseArray @ { {1, 0, 2}, {1/2, 1/3, 1/4} };
+    matB = SparseArray @ { {0, 1}, {1, 0}, {1, 1} };
+    matC = SparseMatMul[matA, matB, "Threads" -> $ProcessorCount];
+    
+    (* Finite Field *)
+    matA = SparseArray @ { {10, 0, 20}, {30, 40, 50} };
+    matB = SparseArray @ { {1, 2}, {3, 4}, {5, 6} };
+    p = 11;
+    matC = SparseMatMul[matA, matB, Modulus -> p, "Threads" -> $ProcessorCount];
 *)
+
 
 BeginPackage["SparseRREF`"];
 
 Unprotect["SparseRREF`*"];
+
 
 Options[SparseRREF] = {
   Modulus -> 0,
@@ -72,6 +99,24 @@ SparseRREF::findlib = "SparseRREF library \"`1`\" not found at `2`";
 SparseRREF::optionvalue = "Invalid SparseRREF option value: `1` -> `2`. Allowed values: `3`";
 SparseRREF::rettype = "SparseRREF should return SparseArray or List, but returned: `1`";
 
+
+Options[SparseMatMul] = {
+  Modulus -> 0,
+  "Threads" -> 1
+};
+
+SparseMatMul::usage =
+  "SparseMatMul[matA, matB, opts] computes the exact matrix multiplication of two sparse rational matrices " <>
+  "or two sparse integer matrices modulo prime p (if Modulus -> p is specified). " <>
+  "Default options: " <> ToString @ Options @ SparseMatMul;
+
+SyntaxInformation[SparseMatMul] = {"ArgumentsPattern" -> {_, _, OptionsPattern[]}}
+
+SparseMatMul::optionvalue = "Invalid SparseMatMul option value: `1` -> `2`. Allowed values: `3`";
+SparseMatMul::rettype = "SparseMatMul should return SparseArray, but returned: `1`";
+SparseMatMul::dims = "Matrices `1` and `2` have incompatible dimensions.";
+
+
 Begin["`Private`"];
 
 (* Load SparseRREF library *)
@@ -86,7 +131,8 @@ If[FailureQ[$sparseRREFLib],
   Message[SparseRREF::findlib, $sparseRREFLibName, $sparseRREFDirectory];
 ];
 
-(* TODO: provide API for other exported functions: modpmatmul, ratmat_inv *)
+
+(* TODO: provide API for other exported function(s): sprref_rat_matinv *)
 
 ratRREFLibFunction =
   LibraryFunctionLoad[
@@ -120,6 +166,33 @@ modRREFLibFunction =
     },
     {LibraryDataType[ByteArray], Automatic}
   ];
+
+
+ratMatMulLibFunction =
+  LibraryFunctionLoad[
+    $sparseRREFLib,
+    "sprref_rat_matmul",
+    {
+      {LibraryDataType[ByteArray], "Constant"},
+      {LibraryDataType[ByteArray], "Constant"},
+      Integer
+    },
+    {LibraryDataType[ByteArray], Automatic}
+  ];
+
+modMatMulLibFunction =
+  LibraryFunctionLoad[
+    $sparseRREFLib,
+    "sprref_mod_matmul",
+    {
+      {LibraryDataType[SparseArray], "Constant"},
+      {LibraryDataType[SparseArray], "Constant"},
+      Integer,
+      Integer
+    },
+    {LibraryDataType[SparseArray], Automatic}
+  ];
+
 
 (* Helper functions: parse options, validate etc. *)
 
@@ -188,13 +261,14 @@ parseVerbose[b_] := throwOptionError["Verbose", b, {True, False}];
 parsePrintStep[ps_?IntegerQ] /; ps > 0 := ps;
 parsePrintStep[ps_] := throwOptionError["PrintStep", ps, "1,2,3..."];
 
-checkResult[res_SparseArray] := res;
-checkResult[res_List] := res;
-checkResult[res_] :=
-  (
-    Message[SparseRREF::rettype, res];
+checkResult[msg_, res_, pattern_] :=
+  If[MatchQ[res, pattern],
+    res,
+    Message[msg, res];
     Throw[$Failed]
-  );
+  ];
+SetAttributes[checkResult, HoldFirst];
+
 
 (* Define public function SparseRREF[] *)
 
@@ -209,13 +283,17 @@ SparseRREF[mat_SparseArray, opts : OptionsPattern[] ] :=
       $verbose = parseVerbose @ OptionValue["Verbose"],
       $printStep = parsePrintStep @ OptionValue["PrintStep"]
     },
-    checkResult @ If[$modulus == 0,
-      rationalRREF[mat, $outputMode, $method, $backwardSubstitution, $threads, $verbose, $printStep],
-      modRREF[mat, $modulus, $outputMode, $method, $backwardSubstitution, $threads, $verbose, $printStep]
+    checkResult[
+      SparseRREF::rettype,
+      If[$modulus == 0,
+        ratRREF[mat, $outputMode, $method, $backwardSubstitution, $threads, $verbose, $printStep],
+        modRREF[mat, $modulus, $outputMode, $method, $backwardSubstitution, $threads, $verbose, $printStep]
+      ],
+      _SparseArray | _List
     ]
   ];
 
-rationalRREF[
+ratRREF[
     mat_SparseArray,
     outputMode_?IntegerQ,
     method_?IntegerQ,
@@ -254,6 +332,56 @@ modRREF[
     verbose,
     printStep
   ];
+
+
+(* Define public function SparseMatMul[] *)
+
+SparseMatMul[matA_SparseArray, matB_SparseArray, opts : OptionsPattern[] ] :=
+  Catch @ With[
+    {
+      $modulus = parseModulus @ OptionValue["Modulus"],
+      $threads = parseThreads @ OptionValue["Threads"],
+      $dimA = Dimensions[matA],
+      $dimB = Dimensions[matB]
+    },
+    If[Last[$dimA] != First[$dimB],
+      Message[SparseMatMul::dims, matA, matB];
+      Throw[$Failed];
+    ];
+    checkResult[
+      SparseMatMul::rettype,
+      If[$modulus == 0,
+        ratMatMul[matA, matB, $threads],
+        modMatMul[matA, matB, $modulus, $threads]
+      ],
+      _SparseArray
+    ]
+  ];
+
+ratMatMul[
+    matA_SparseArray,
+    matB_SparseArray,
+    threads_?IntegerQ
+  ] :=
+  BinaryDeserialize @ ratMatMulLibFunction[
+    BinarySerialize[matA],
+    BinarySerialize[matB],
+    threads
+  ];
+
+modMatMul[
+    matA_SparseArray,
+    matB_SparseArray,
+    p_?PrimeQ,
+    threads_?IntegerQ
+  ] :=
+  modMatMulLibFunction[
+    matA,
+    matB,
+    p,
+    threads
+  ];
+
 
 With[{syms = Names["SparseRREF`*"]},
   SetAttributes[syms, {Protected, ReadProtected}]

--- a/sparse_mat.h
+++ b/sparse_mat.h
@@ -2072,7 +2072,14 @@ namespace SparseRREF {
 		if (F.ring == RING::FIELD_Fp)
 			pivots = sparse_mat_rref(M1, F, opt);
 		else if (F.ring == RING::FIELD_QQ)
-			pivots = sparse_mat_rref_reconstruct(M1, opt, true);
+			if constexpr (std::is_same_v<T, rat_t>) {
+				pivots = sparse_mat_rref_reconstruct(M1, opt, true);
+			}
+			else {
+				// type is not rat_t when field is QQ
+				std::cerr << "Warning: sparse_mat_inverse: type is not rat_t when field is QQ" << std::endl;
+				pivots = sparse_mat_rref(M1, F, opt);
+			}
 		else {
 			std::cerr << "Error: sparse_mat_inverse: field not supported" << std::endl;
 			// restore the option

--- a/sprreflink.cpp
+++ b/sprreflink.cpp
@@ -784,6 +784,32 @@ EXTERN_C DLLEXPORT int sprref_rat_rref(WolframLibraryData ld, mint Argc, MArgume
 	return err;
 }
 
+EXTERN_C DLLEXPORT int sprref_mod_matinv(WolframLibraryData ld, mint Argc, MArgument* Args, MArgument Res) {
+	if (Argc != 3)
+		return LIBRARY_FUNCTION_ERROR;
+	auto mat_in = MArgument_getMSparseArray(Args[0]);
+	auto p = MArgument_getInteger(Args[1]);
+	auto nthreads = MArgument_getInteger(Args[2]);
+	auto sf = ld->sparseLibraryFunctions;
+	auto ranks = sf->MSparseArray_getRank(mat_in);
+	if (ranks != 2 && sf->MSparseArray_getImplicitValue(mat_in) != 0)
+		return LIBRARY_FUNCTION_ERROR;
+	auto mat = MSparseArray_to_sparse_mat_ulong(ld, Args, (ulong)p);
+	if (mat.ncol != mat.nrow)
+		return LIBRARY_FUNCTION_ERROR;
+	field_t F(FIELD_Fp, p);
+	int err = 0;
+	MSparseArray result = 0;
+	rref_option_t opt;
+	opt->pool.reset(nthreads);
+	auto inv_mat = sparse_mat_inverse(mat, F, opt);
+	err = sparse_mat_ulong_to_MSparseArray(ld, result, inv_mat);
+	if (err)
+		return LIBRARY_FUNCTION_ERROR;
+	MArgument_setMSparseArray(Res, result);
+	return LIBRARY_NO_ERROR;
+}
+
 EXTERN_C DLLEXPORT int sprref_rat_matinv(WolframLibraryData ld, mint Argc, MArgument* Args, MArgument Res) {
 	if (Argc != 2)
 		return LIBRARY_FUNCTION_ERROR;


### PR DESCRIPTION
### CHANGES

- add `SparseMatMul`, `SparseTensorContract`, `SparseTensorDot` and `SparseMatInv` for `SparseRREF.wl`
- rename the shared library from `mathlink`/`mma_link.cpp` to `sprreflink`/`sprreflink.cpp`
- unify API naming rules (e.g. `rational_rref` to `sprref_rat_rref`)

